### PR TITLE
fix: misc bug fixes

### DIFF
--- a/cmd/databox/cmd.cp.go
+++ b/cmd/databox/cmd.cp.go
@@ -73,7 +73,8 @@ func cpLocalCmd(stdout, stderr dio.DataWriter) {
 	dio.AssertError(stderr, err, *cpDebug, "Failed to query columns for "+srcTable+": %v")
 
 	// Drop destination table before copy
-	con.GetConnection().Exec("DROP TABLE IF EXISTS " + sm.QuoteIdentifier(dstTable))
+	_, err = con.GetConnection().Exec("DROP TABLE IF EXISTS " + sm.QuoteIdentifier(dstTable))
+	dio.AssertError(stderr, err, *cpDebug, "Failed to drop destination table "+dstTable+": %v")
 
 	// Build and execute CREATE TABLE on destination
 	err = sm.CreateTable(dstTable, columns)

--- a/cmd/databox/cmd.dsn.go
+++ b/cmd/databox/cmd.dsn.go
@@ -95,7 +95,7 @@ func dsnCmd() {
 		dio.AssertError(stderr, err, *dsnDebug, "Failed to get current user: %v")
 		user := conv.String(data.Rows[0][0])
 		// Get database size
-		data, err = con.QueryData(fmt.Sprintf("SELECT pg_database_size('%s');", dbName))
+		data, err = con.QueryData("SELECT pg_database_size($1);", dbName)
 		dio.AssertError(stderr, err, *dsnDebug, "Failed to get database size: %v")
 		size := conv.Int(data.Rows[0][0])
 		sizeStr := humanize.Bytes(uint64(size))
@@ -104,7 +104,7 @@ func dsnCmd() {
 		dio.AssertError(stderr, err, *dsnDebug, "Failed to get table count: %v")
 		tableCount := conv.Int(data.Rows[0][0])
 		// Get active connections
-		data, err = con.QueryData(fmt.Sprintf("SELECT COUNT(*) FROM pg_stat_activity WHERE datname = '%s';", dbName))
+		data, err = con.QueryData("SELECT COUNT(*) FROM pg_stat_activity WHERE datname = $1;", dbName)
 		dio.AssertError(stderr, err, *dsnDebug, "Failed to get active connections: %v")
 		activeConns := conv.Int(data.Rows[0][0])
 		// Write resulting information
@@ -133,12 +133,12 @@ func dsnCmd() {
 		dio.AssertError(stderr, err, *dsnDebug, "Failed to get current user: %v")
 		user := conv.String(data.Rows[0][0])
 		// Get database size
-		data, err = con.QueryData(fmt.Sprintf("SELECT SUM(data_length + index_length) FROM information_schema.tables WHERE table_schema = '%s';", dbName))
+		data, err = con.QueryData("SELECT SUM(data_length + index_length) FROM information_schema.tables WHERE table_schema = ?;", dbName)
 		dio.AssertError(stderr, err, *dsnDebug, "Failed to get database size: %v")
 		size := conv.Int(data.Rows[0][0])
 		sizeStr := humanize.Bytes(uint64(size))
 		// Get table count
-		data, err = con.QueryData(fmt.Sprintf("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '%s';", dbName))
+		data, err = con.QueryData("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ?;", dbName)
 		dio.AssertError(stderr, err, *dsnDebug, "Failed to get table count: %v")
 		tableCount := conv.Int(data.Rows[0][0])
 		// Get active connections

--- a/cmd/databox/cmd.head.go
+++ b/cmd/databox/cmd.head.go
@@ -59,7 +59,7 @@ func headCmd() {
 		colClause(*headCol), table, whereClause(*headWhere), orderClause(*headOrder), *headN)
 	dio.Stream(dio.StreamParameters{
 		Con: con, Stdout: stdout, Stderr: stderr,
-		Debug: *headDebug,
+		Debug: *headDebug, Nowarn: *headNowarn,
 		Table: table, Query: query,
 	})
 }

--- a/cmd/databox/cmd.migrate.go
+++ b/cmd/databox/cmd.migrate.go
@@ -104,7 +104,8 @@ func migrateRunCmd(stdout, stderr dio.DataWriter) {
 
 	// Drop destination tables before migration
 	for _, table := range tables {
-		dstCon.GetConnection().Exec("DROP TABLE IF EXISTS " + dstSm.QuoteIdentifier(table.Name))
+		_, err := dstCon.GetConnection().Exec("DROP TABLE IF EXISTS " + dstSm.QuoteIdentifier(table.Name))
+		dio.AssertError(stderr, err, *migrateDebug, "Failed to drop destination table "+table.Name+": %v")
 	}
 
 	// Track row counts per table for summary

--- a/cmd/databox/cmd.tail.go
+++ b/cmd/databox/cmd.tail.go
@@ -84,7 +84,7 @@ func tailCmd() {
 
 	dio.Stream(dio.StreamParameters{
 		Con: con, Stdout: stdout, Stderr: stderr,
-		Debug: *tailDebug,
+		Debug: *tailDebug, Nowarn: *tailNowarn,
 		Table: table, Query: query,
 	})
 }

--- a/pkg/db/mysql.go
+++ b/pkg/db/mysql.go
@@ -142,19 +142,19 @@ func (m *Mysql) GetTables() ([]Table, error) {
 
 func (m *Mysql) GetColumns(table string) ([]Column, error) {
 	// Query the database for the columns
-	dataCols, err := m.QueryData(fmt.Sprintf(`
+	dataCols, err := m.QueryData(`
 		SELECT
 			column_name,
 			data_type,
 			(CASE WHEN is_nullable = 'YES' THEN true ELSE false END) AS is_nullable,
 			column_default
 		FROM information_schema.columns
-		WHERE table_name = '%s'`, table))
+		WHERE table_name = ?`, table)
 	if err != nil {
 		return nil, err
 	}
 	// Query the database for constraints
-	dataCons, err := m.QueryData(fmt.Sprintf(`
+	dataCons, err := m.QueryData(`
 		SELECT DISTINCT
 		    tc.CONSTRAINT_NAME,
 		    tc.CONSTRAINT_TYPE,
@@ -173,8 +173,8 @@ func (m *Mysql) GetColumns(table string) ([]Column, error) {
 		      ON rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
 		      AND rc.CONSTRAINT_SCHEMA = tc.TABLE_SCHEMA
 		WHERE
-		    tc.TABLE_NAME = '%s';
-		`, table))
+		    tc.TABLE_NAME = ?;
+		`, table)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/db/postgres.go
+++ b/pkg/db/postgres.go
@@ -54,19 +54,19 @@ func (p *Postgres) GetTables() ([]Table, error) {
 
 func (p *Postgres) GetColumns(table string) ([]Column, error) {
 	// Query the database for the columns
-	dataCols, err := p.QueryData(fmt.Sprintf(`
+	dataCols, err := p.QueryData(`
 		SELECT
 			column_name,
 			data_type,
 			(CASE WHEN is_nullable = 'YES' THEN true ELSE false END) AS is_nullable,
 			column_default
 		FROM information_schema.columns
-		WHERE table_name = '%s'`, table))
+		WHERE table_name = $1`, table)
 	if err != nil {
 		return nil, err
 	}
 	// Query the database for constraints
-	dataCons, err := p.QueryData(fmt.Sprintf(`
+	dataCons, err := p.QueryData(`
 		SELECT DISTINCT
 		    tc.constraint_name,
 		    tc.constraint_type,
@@ -87,8 +87,8 @@ func (p *Postgres) GetColumns(table string) ([]Column, error) {
 			LEFT JOIN information_schema.referential_constraints AS fk
 			  ON fk.constraint_name = tc.constraint_name
 		WHERE
-		     tc.table_name = '%s';
-		`, table))
+		     tc.table_name = $1;
+		`, table)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -56,7 +56,7 @@ func (s *Sqlite) GetColumns(table string) ([]Column, error) {
 	// We can't select exact fields because of 'notnull' issue (syntax error near "notnull").
 	// So, here is a reference column list:
 	// cid, name, type, notnull, dflt_value, pk
-	dataCols, err := s.QueryData(fmt.Sprintf("SELECT * FROM PRAGMA_TABLE_INFO('%s')", table))
+	dataCols, err := s.QueryData("SELECT * FROM PRAGMA_TABLE_INFO(?)", table)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (s *Sqlite) GetColumns(table string) ([]Column, error) {
 	// Same as above, we can't select exact fields because of syntax error.
 	// So, here is a reference column list:
 	// id, seq, table, from, to, on_update, on_delete, match
-	dataFks, err := s.QueryData(fmt.Sprintf("SELECT * FROM PRAGMA_FOREIGN_KEY_LIST('%s')", table))
+	dataFks, err := s.QueryData("SELECT * FROM PRAGMA_FOREIGN_KEY_LIST(?)", table)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

A few correctness fixes found while reading through the code.

- **head/tail: `-nowarn` flag ignored.** Both commands register the flag but never pass it to `dio.Stream`, so the row-cap warning fires even when `-nowarn` is set. `cat` does pass it correctly — aligned head/tail with that.
- **cp / migrate: `DROP TABLE IF EXISTS` error discarded.** If the DROP fails (permissions, FK from another table, etc.) the error was silently swallowed and the subsequent `CREATE TABLE` then failed with a confusing "already exists". Now surfaces the real cause.
- **`GetColumns` in postgres/mysql/sqlite used `fmt.Sprintf` for table names.** Tables whose names contain a single quote would break the lookup. Switched to parameterized queries (`$1` / `?` / PRAGMA bind param). Same treatment for the `dbName` lookups in `cmd dsn` (postgres + mysql size/connection/table-count queries).

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] Sqlite smoke test: `head`, `tail`, `cp -schema-data` (exercises the parameterized `GetColumns` + `DROP TABLE` error path) — all work
- [ ] Postgres / MySQL smoke — I didn't have instances handy; the changes are mechanical (Sprintf → bind) but worth a quick run on your side